### PR TITLE
add requirements in doc workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - name: Install dependencies
+      - name: Install scalr requirements
         run: |
-          pip install sphinx sphinx_rtd_theme myst_parser
+          pip install -r requirements.txt
+      - name: Install sphinx dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme myst_parser 
       - name: Sphinx build
         run: |
           sphinx-build docs _build

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ PyYAML==6.0.2
 scanpy==1.10.3
 scikit-learn==1.5.2
 shap==0.46.0
-sphinx-rtd-theme==2.0.0
 tensorboard==2.17.0
 toml==0.10.2
 torch==2.4.1 --index-url https://download.pytorch.org/whl/cu118


### PR DESCRIPTION
Added `scalr requirements` to be installed while running documentation workflow. This was done to resolve the error raised during building module docs, which needs some dependencies related to scalr.